### PR TITLE
more data on events

### DIFF
--- a/lib/mpv.rb
+++ b/lib/mpv.rb
@@ -9,5 +9,5 @@ require_relative "mpv/session"
 # The toplevel namespace for ruby-mpv.
 module MPV
   # The current version of ruby-mpv.
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end

--- a/lib/mpv/client.rb
+++ b/lib/mpv/client.rb
@@ -122,7 +122,7 @@ module MPV
       response = JSON.parse(@socket.readline)
 
       if response["event"]
-        @event_queue << response["event"]
+        @event_queue << response
       else
         @result_queue << response
       end


### PR DESCRIPTION
Some of mpv's events have more data other than just the event name.  For instance the property-change event also has a "name" value that contains the name of the property that changed.  If you add the entire hash to the event_queue rather than just the event type, the callbacks will have access to this information.
