### PR TITLE
Fix crash with ruby 2.5.0 'No method Dir::Tmpname.make_tmpname'

### DIFF
--- a/lib/mpv.rb
+++ b/lib/mpv.rb
@@ -9,5 +9,5 @@ require_relative "mpv/session"
 # The toplevel namespace for ruby-mpv.
 module MPV
   # The current version of ruby-mpv.
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end

--- a/lib/mpv.rb
+++ b/lib/mpv.rb
@@ -9,5 +9,5 @@ require_relative "mpv/session"
 # The toplevel namespace for ruby-mpv.
 module MPV
   # The current version of ruby-mpv.
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end

--- a/lib/mpv/client.rb
+++ b/lib/mpv/client.rb
@@ -122,7 +122,7 @@ module MPV
       response = JSON.parse(@socket.readline)
 
       if response["event"]
-        @event_queue << response["event"]
+        @event_queue << response
       else
         @result_queue << response
       end

--- a/lib/mpv/server.rb
+++ b/lib/mpv/server.rb
@@ -52,7 +52,7 @@ module MPV
     #  (defaults to a tmpname in `/tmp`)
     # @param user_args [Array<String>] additional arguments to use when
     #  spawning mpv
-    def initialize(path: File.join('/tmp', Utils.tmpname), user_args: [])
+    def initialize(path: File.join('/tmp', Utils.tmpsock), user_args: [])
       @socket_path = path
       @args = [
         "--idle",

--- a/lib/mpv/server.rb
+++ b/lib/mpv/server.rb
@@ -52,9 +52,7 @@ module MPV
     #  (defaults to a tmpname in `/tmp`)
     # @param user_args [Array<String>] additional arguments to use when
     #  spawning mpv
-    def initialize(path: Dir::Tmpname.make_tmpname("/tmp/mpv", ".sock"),
-                   user_args: [])
-
+    def initialize(path: File.join('/tmp', Utils.tmpname), user_args: [])
       @socket_path = path
       @args = [
         "--idle",

--- a/lib/mpv/session.rb
+++ b/lib/mpv/session.rb
@@ -21,8 +21,7 @@ module MPV
     #  (defaults to a tmpname in `/tmp`)
     # @param user_args [Array<String>] additional arguments to use when
     #  spawning mpv
-    def initialize(path: Dir::Tmpname.make_tmpname("/tmp/mpv", ".sock"),
-                   user_args: [])
+    def initialize(path: File.join('/tmp', Utils.tmpname), user_args: [])
       @socket_path = path
 
       @server = Server.new(path: @socket_path, user_args: user_args)

--- a/lib/mpv/session.rb
+++ b/lib/mpv/session.rb
@@ -21,7 +21,7 @@ module MPV
     #  (defaults to a tmpname in `/tmp`)
     # @param user_args [Array<String>] additional arguments to use when
     #  spawning mpv
-    def initialize(path: File.join('/tmp', Utils.tmpname), user_args: [])
+    def initialize(path: File.join('/tmp', Utils.tmpsock), user_args: [])
       @socket_path = path
 
       @server = Server.new(path: @socket_path, user_args: user_args)

--- a/lib/mpv/utils.rb
+++ b/lib/mpv/utils.rb
@@ -12,5 +12,10 @@ module MPV
         File.executable?(File.join(path, util))
       end
     end
+
+    def self.tmpname
+      t = Time.now.strftime("%Y%m%d")
+      "mpv#{t}-#{$$}-#{rand(0x100000000).to_s(36)}.sock"
+    end
   end
 end

--- a/lib/mpv/utils.rb
+++ b/lib/mpv/utils.rb
@@ -13,7 +13,7 @@ module MPV
       end
     end
 
-    def self.tmpname
+    def self.tmpsock
       t = Time.now.strftime("%Y%m%d")
       "mpv#{t}-#{$$}-#{rand(0x100000000).to_s(36)}.sock"
     end


### PR DESCRIPTION
Ruby 2.5.0 removed the method `make_tmpname` ( https://github.com/ruby/ruby/commit/25d56ea7b7b52dc81af30c92a9a0e2d2dab6ff27 ), so I implemented the same [fix](https://github.com/rails/rails/pull/31462/files) that the rails team used.